### PR TITLE
Ensure that the callback is called only once.

### DIFF
--- a/lib/after_layout.dart
+++ b/lib/after_layout.dart
@@ -3,11 +3,17 @@ library after_layout;
 import 'package:flutter/widgets.dart';
 
 mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
+  bool _hasBeenCalled;
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => afterFirstLayout(context));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if(true != _hasBeenCalled) {
+        _hasBeenCalled = true;
+        afterFirstLayout(context);
+      }
+    });
   }
 
   void afterFirstLayout(BuildContext context);


### PR DESCRIPTION
I've used this plugin for a while now and I noticed that the callback sometimes is called twice, and I'm certain it's not a problem in my code. So this small fix will ensure that it's indeed called once.